### PR TITLE
Implement route transition overlay

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <app-header></app-header>
+<div class="app__transition-overlay" [class.active]="showTransition"></div>
 @if (showIntro) {
   <div class="app__intro-overlay"></div>
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,6 +11,20 @@
   }
 }
 
+.app__transition-overlay {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 9998;
+}
+.app__transition-overlay.active {
+  opacity: 0.6;
+  pointer-events: auto;
+}
+
 @keyframes introFadeOut {
   0% {
     opacity: 1;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,7 +4,14 @@ import {
   fakeAsync,
   tick,
 } from '@angular/core/testing';
-import { ActivatedRoute, RouterOutlet } from '@angular/router';
+import {
+  ActivatedRoute,
+  NavigationEnd,
+  NavigationStart,
+  Router,
+  RouterOutlet,
+} from '@angular/router';
+import { Subject } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './componenets/header/header.component';
@@ -12,8 +19,16 @@ import { HeaderComponent } from './componenets/header/header.component';
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let events$: Subject<NavigationStart | NavigationEnd>;
 
   beforeEach(async () => {
+    events$ = new Subject<NavigationStart | NavigationEnd>();
+    routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl'], {
+      events: events$.asObservable(),
+      url: '/',
+    });
+
     await TestBed.configureTestingModule({
       imports: [
         AppComponent,
@@ -21,7 +36,10 @@ describe('AppComponent', () => {
         HeaderComponent,
         TranslateModule.forRoot(),
       ],
-      providers: [{ provide: ActivatedRoute, useValue: {} }],
+      providers: [
+        { provide: ActivatedRoute, useValue: {} },
+        { provide: Router, useValue: routerSpy },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AppComponent);
@@ -48,5 +66,16 @@ describe('AppComponent', () => {
     fixture.detectChanges();
 
     expect(component.showIntro).toBeFalse();
+  }));
+
+  it('should toggle transition overlay on navigation', fakeAsync(() => {
+    events$.next(new NavigationStart(1, '/')); 
+    fixture.detectChanges();
+    expect(component.showTransition).toBeTrue();
+
+    events$.next(new NavigationEnd(1, '/', '/')); 
+    tick(300);
+    fixture.detectChanges();
+    expect(component.showTransition).toBeFalse();
   }));
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,12 @@
-import { Component, OnInit } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Component, OnInit, DestroyRef, inject } from '@angular/core';
+import {
+  NavigationEnd,
+  NavigationStart,
+  Router,
+  RouterOutlet,
+} from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { timer } from 'rxjs';
 import { HeaderComponent } from './componenets/header/header.component';
 
 @Component({
@@ -10,10 +17,30 @@ import { HeaderComponent } from './componenets/header/header.component';
 })
 export class AppComponent implements OnInit {
   showIntro = true;
+  showTransition = false;
+
+  private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   ngOnInit() {
     setTimeout(() => {
       this.showIntro = false;
     }, 1500);
+
+    this.router.events
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event) => {
+        if (event instanceof NavigationStart) {
+          this.showTransition = true;
+        }
+
+        if (event instanceof NavigationEnd) {
+          timer(300)
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => {
+              this.showTransition = false;
+            });
+        }
+      });
   }
 }


### PR DESCRIPTION
## Summary
- add transition overlay state and router navigation handling
- show overlay element in root template
- style overlay with fade effect
- test route transitions in AppComponent

## Testing
- `npm install`
- `npm test` *(fails: No Chrome binary)*
- `ng serve` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407eb15ed8832483832c23c8fdc03b