### PR TITLE
Feature/applying review changes base on o3 sugesstions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,27 @@ cdk bootstrap
 
 ```ts
 npm i
-npm run build
+NONCE=$(openssl rand -base64 16) //generate NONCE for style file
+CSP_NONCE="$NONCE" npm run build  //pass CSP_NONCE to build it runs later postbuild script that adds this nonce value
+HANDLER_HASH=$(cat dist/handlerHash.txt) //for CSP to get rid console error
 ```
 
-3. Deploy Infra
+3. Check Infra file setup
 
 ```ts
 cd infra
 npm i
-npx cdk deploy
+npx cdk synth
 ```
 
-4. Pray
+4. Deploy changes
+
+```ts
+npx cdk deploy
+npx cdk deploy -c stage=dev -c cspNonce="$NONCE" -c handlerHash="$HANDLER_HASH"  //if you want to deploy as pointed environment
+```
+
+5. Pray
 
 🙏🙏🙏
 
@@ -66,6 +75,14 @@ npm run lint
 ```
 
 I encourage to use and force lint for every run
+
+# Useful commands:
+
+1. Invlidation of cloudfront
+
+```bash
+aws cloudfront create-invalidation --distribution-id {{id}} --paths "/*"
+```
 
 # TODO:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build:watch": "ng build --watch --configuration development",
+    "postbuild": "node scripts/add-csp-nonce.js",
     "test": "ng test --browsers=ChromeHeadlessNoSandbox --watch=false",
     "test:watch": "ng test --browsers=ChromeHeadlessNoSandbox --watch=true",
     "lint": "eslint .",

--- a/frontend/scripts/add-csp-nonce.js
+++ b/frontend/scripts/add-csp-nonce.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const path = require("path");
+
+const nonce = process.env.CSP_NONCE;
+if (!nonce) throw new Error("CSP_NONCE env var missing");
+
+const indexPath = path.join(
+  __dirname,
+  "..",
+  "dist",
+  "portfolio-website",
+  "browser",
+  "index.html",
+);
+let html = fs.readFileSync(indexPath, "utf8");
+
+// add nonce to ALL inline <style> tags (Angular usually has only one)
+html = html.replace(/<style(?![^>]*nonce)/g, `<style nonce="${nonce}"`);
+html = html.replace(
+  "</head>",
+  `<meta name="csp-nonce" content="${nonce}"></head>`,
+);
+
+fs.writeFileSync(indexPath, html);
+console.log("✅ CSP nonce injected into index.html");
+
+const crypto = require("crypto");
+const handler = "this.media='all'";
+const handlerHash = crypto
+  .createHash("sha256")
+  .update(handler)
+  .digest("base64");
+fs.writeFileSync(
+  path.join(__dirname, "..", "dist", "handlerHash.txt"),
+  handlerHash,
+);
+console.log("✅ CSP media hash generated");

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { HttpClient, provideHttpClient } from '@angular/common/http';
 import {
   ApplicationConfig,
+  CSP_NONCE,
   importProvidersFrom,
   provideZoneChangeDetection,
 } from '@angular/core';
@@ -37,5 +38,12 @@ export const appConfig: ApplicationConfig = {
         preventDuplicates: true,
       }),
     ),
+    {
+      provide: CSP_NONCE,
+      useFactory: () =>
+        document
+          .querySelector('meta[name="csp-nonce"]')
+          ?.getAttribute('content') ?? '',
+    },
   ],
 };

--- a/infra/lib/portfolio-hosting-stack.ts
+++ b/infra/lib/portfolio-hosting-stack.ts
@@ -1,13 +1,11 @@
-import {
-  CfnOutput,
-  Duration,
-  RemovalPolicy,
-  Stack,
-  StackProps,
-} from "aws-cdk-lib";
+import { CfnOutput, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
 import {
   Distribution,
+  HeadersFrameOption,
+  HeadersReferrerPolicy,
   OriginAccessIdentity,
+  PriceClass,
+  ResponseHeadersPolicy,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
 import { S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
@@ -19,17 +17,39 @@ import {
 } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
+import { randomBytes } from "crypto";
+import { SpaHostingStackProps } from "./types";
 
 export class SpaHostingStack extends Stack {
-  constructor(scope: Construct, id: string, props?: StackProps) {
+  constructor(scope: Construct, id: string, props?: SpaHostingStackProps) {
     super(scope, id, props);
+
+    const nonce =
+      this.node.tryGetContext("cspNonce") ?? randomBytes(16).toString("base64");
+    const handlerHash = this.node.tryGetContext("handlerHash") ?? "";
+
+    // Access Logs  receives server-access logs (one line per object request: IP, user-agent, bytes, result).
+    const logsBucket = new Bucket(this, "AccessLogs", {
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      lifecycleRules: [
+        {
+          expiration: Duration.days(14),
+        },
+      ],
+    });
 
     // 1) Private, encrypted bucket
     const portfolioBucket = new Bucket(this, "PortfolioBucket", {
-      bucketName: `portfolio-website-${this.stackName.toLowerCase()}`,
+      bucketName: `portfolio-website-${this.stackName.toLowerCase()}-${
+        props?.stage || "dev"
+      }`,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: RemovalPolicy.DESTROY,
+      removalPolicy: RemovalPolicy.DESTROY, // Intentionaly set to avoid costs and clean entirely
+      autoDeleteObjects: true,
       encryption: BucketEncryption.S3_MANAGED,
+      serverAccessLogsBucket: logsBucket,
+      serverAccessLogsPrefix: "s3/",
     });
 
     // 2) Create an Origin Access Identity (OAI)
@@ -65,13 +85,62 @@ export class SpaHostingStack extends Stack {
       originAccessIdentity: oai,
     });
 
+    // Inject security headers via CloudFront
+    const securityHeaders = new ResponseHeadersPolicy(this, "SecurityHeaders", {
+      securityHeadersBehavior: {
+        strictTransportSecurity: {
+          accessControlMaxAge: Duration.days(365),
+          includeSubdomains: true,
+          preload: true,
+          override: true,
+        },
+        contentTypeOptions: { override: true },
+        referrerPolicy: {
+          referrerPolicy: HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+          override: true,
+        },
+        frameOptions: {
+          frameOption: HeadersFrameOption.DENY,
+          override: true,
+        },
+        contentSecurityPolicy: {
+          contentSecurityPolicy: [
+            "default-src 'self'",
+            `style-src-elem 'self' 'nonce-${nonce}'`,
+            // "style-src-attr 'unsafe-inline'", // removed as angular uses nonce
+            `script-src 'self' 'nonce-${nonce}' 'unsafe-hashes' 'sha256-${handlerHash}'`,
+            "img-src 'self' data: https:",
+            "upgrade-insecure-requests",
+            "block-all-mixed-content",
+          ].join("; "),
+          override: true,
+        },
+      },
+      customHeadersBehavior: {
+        customHeaders: [
+          {
+            header: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+            override: true,
+          },
+          {
+            header: "Cross-Origin-Resource-Policy",
+            value: "same-origin",
+            override: true,
+          },
+        ],
+      },
+    });
+
     // 4) CloudFront distribution
     const distribution = new Distribution(this, "PortfolioDistribution", {
       defaultRootObject: "index.html",
       defaultBehavior: {
         origin: s3Origin,
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        responseHeadersPolicy: securityHeaders,
       },
+      priceClass: PriceClass.PRICE_CLASS_100,
       errorResponses: [
         {
           httpStatus: 403,

--- a/infra/lib/types.ts
+++ b/infra/lib/types.ts
@@ -1,0 +1,5 @@
+import { StackProps } from "aws-cdk-lib";
+
+export interface SpaHostingStackProps extends StackProps {
+  stage: string;
+}


### PR DESCRIPTION
O3 sugessted and I added:
- Add a BucketAccessLogging target bucket. ✅
- production use RETAIN so you don’t nuke real data by mistake - this one I omit as it's mostly my app that I often destroy as stack and redeploy and cleaning buckets is annoying so I allowed to clear them
- Consider adding ${props?.env?.account} or a stage suffix so parallel environments don’t collide. ✅
- Add ResponseHeadersPolicy to inject security headers (CSP, HSTS, X-Content-Type-Options). ✅
