### PR TITLE
Improve landing page UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ aws cloudfront create-invalidation --distribution-id {{id}} --paths "/*"
 - [x] add linter during pushing
 - [x] add github rules to not push on master + require positive pipeline for merging
 - [x] mobile styles - for current state seems to looks well
-- [ ] increase UX for landing page scrolling
+- [x] increase UX for landing page scrolling
 - [x] implement faker for tests
 - [ ] add docker for aws env
+
+## Landing Page UX Improvements
+
+The landing page now respects the user's `prefers-reduced-motion` setting and
+reveals content slightly earlier while keeping animations quick. The scroll
+indicator stays visible until the page is scrolled more than 100&nbsp;px and
+fades out smoothly.

--- a/frontend/src/app/componenets/landing-page/about/about.component.scss
+++ b/frontend/src/app/componenets/landing-page/about/about.component.scss
@@ -81,3 +81,10 @@
     }
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .about__line,
+  .about__tag-row {
+    transition: none;
+  }
+}

--- a/frontend/src/app/componenets/landing-page/about/about.component.ts
+++ b/frontend/src/app/componenets/landing-page/about/about.component.ts
@@ -45,8 +45,8 @@ export class AboutComponent implements OnInit {
   interestChunks: string[][] = [];
   descriptionLines = [
     { key: 'ABOUT.DESCRIPTION_LINE_1', delay: 0 },
-    { key: 'ABOUT.DESCRIPTION_LINE_2', delay: 0.75 },
-    { key: 'ABOUT.DESCRIPTION_LINE_3', delay: 1.5 },
+    { key: 'ABOUT.DESCRIPTION_LINE_2', delay: 0.5 },
+    { key: 'ABOUT.DESCRIPTION_LINE_3', delay: 1 },
   ];
 
   tagsDelay = this.descriptionLines

--- a/frontend/src/app/componenets/landing-page/hero/hero.component.scss
+++ b/frontend/src/app/componenets/landing-page/hero/hero.component.scss
@@ -50,6 +50,17 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .hero__scroll-indicator {
+    animation: none;
+  }
+
+  .hero__text,
+  .hero__scroll-indicator {
+    transition: none;
+  }
+}
+
 @keyframes bounce {
   0%,
   100% {

--- a/frontend/src/app/componenets/landing-page/hero/hero.component.spec.ts
+++ b/frontend/src/app/componenets/landing-page/hero/hero.component.spec.ts
@@ -63,7 +63,7 @@ describe('HeroComponent', () => {
   });
 
   it('should hide scroll indicator when scrolled', () => {
-    spyOnProperty(window, 'scrollY').and.returnValue(100);
+    spyOnProperty(window, 'scrollY').and.returnValue(150);
     component.onScroll();
     expect(component.isArrowScrollHidden).toBeTrue();
   });

--- a/frontend/src/app/componenets/landing-page/hero/hero.component.ts
+++ b/frontend/src/app/componenets/landing-page/hero/hero.component.ts
@@ -28,21 +28,27 @@ export class HeroComponent implements OnInit, OnDestroy {
 
   @HostListener('window:scroll')
   onScroll() {
-    this.isArrowScrollHidden = window.scrollY > 10;
+    this.isArrowScrollHidden = window.scrollY > 100;
   }
 
   ngOnInit() {
-    this.intervalSub = interval(10_000)
-      .pipe(
-        tap(() => (this.isTextVisible = false)),
-        switchMap(() => timer(1_500)),
-      )
-      .subscribe(() => {
-        this.index = (this.index + 1) % 2;
-        this.currentBackground = `bg-${this.index}`;
-        this.currentMessage = this.messages[this.index];
-        this.isTextVisible = true;
-      });
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    if (!prefersReducedMotion) {
+      this.intervalSub = interval(10_000)
+        .pipe(
+          tap(() => (this.isTextVisible = false)),
+          switchMap(() => timer(1_500)),
+        )
+        .subscribe(() => {
+          this.index = (this.index + 1) % 2;
+          this.currentBackground = `bg-${this.index}`;
+          this.currentMessage = this.messages[this.index];
+          this.isTextVisible = true;
+        });
+    }
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/directives/scroll-reveal.directive.ts
+++ b/frontend/src/app/directives/scroll-reveal.directive.ts
@@ -27,7 +27,10 @@ export class ScrollRevealDirective implements AfterViewInit, OnDestroy {
           this.observer.unobserve(entry.target);
         }
       },
-      { threshold: 0.2 },
+      {
+        threshold: 0.1,
+        rootMargin: '0px 0px -10% 0px',
+      },
     );
 
     this.observer.observe(this.el.nativeElement);


### PR DESCRIPTION
## Summary
- tweak hero animations to honor reduced motion
- hide scroll indicator after 100px scroll
- reveal about section faster
- adjust scroll reveal directive to trigger earlier
- document landing page UX improvements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686949411d20832493618804ce390689